### PR TITLE
add CORS configuration for the application

### DIFF
--- a/src/main/java/com/app/financial/investmentassetapp/config/CorsConfig.java
+++ b/src/main/java/com/app/financial/investmentassetapp/config/CorsConfig.java
@@ -1,0 +1,27 @@
+package com.app.financial.investmentassetapp.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.setAllowedOrigins(List.of("http://localhost:5173"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return new CorsFilter(source);
+    }
+}


### PR DESCRIPTION
Problem: The frontend at http://localhost:5173 was blocked by CORS when calling the API at http://localhost:8080/asset because the backend did not send Access-Control-Allow-Origin.
Solution: Added a global CORS configuration via a new CorsConfig class that registers a CorsFilter and allows:
Allowed origin: http://localhost:5173
Methods: GET, POST, PUT, DELETE, OPTIONS, PATCH
Headers: all
Credentials: allowed
Paths: all (/**), so every REST endpoint (including /asset) is covered.
Files changed: New file src/main/java/.../config/CorsConfig.java.
With this, the frontend can call the API from the dev server without CORS errors. Other origins can be added later by extending the allowedOrigins list in the same config.