### PR TITLE
add AssetContribution and InvestmentsContribution models with control…

### DIFF
--- a/src/main/java/com/app/financial/investmentassetapp/controller/AssetContributionController.java
+++ b/src/main/java/com/app/financial/investmentassetapp/controller/AssetContributionController.java
@@ -1,0 +1,76 @@
+package com.app.financial.investmentassetapp.controller;
+
+import com.app.financial.investmentassetapp.excpetion.AssetNotFoundException;
+import com.app.financial.investmentassetapp.model.AssetContribution;
+import com.app.financial.investmentassetapp.service.AssetContributionService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/asset/contribution")
+public class AssetContributionController {
+
+    @Autowired
+    private AssetContributionService assetContributionService;
+
+    @GetMapping
+    public ResponseEntity<List<AssetContribution>> getAllAssetContribution() {
+        List<AssetContribution> contributions = assetContributionService.getAllAssetContribution();
+        if (contributions.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        } else {
+            return ResponseEntity.ok(contributions);
+        }
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<AssetContribution> getAssetContributionById(@PathVariable Long id) {
+        Optional<AssetContribution> contribution = assetContributionService.getAssetContributionById(id);
+        return contribution.map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/asset/{assetId}")
+    public ResponseEntity<List<AssetContribution>> getContributionsByAssetId(@PathVariable Long assetId) {
+        List<AssetContribution> contributions = assetContributionService.getContributionsByAssetId(assetId);
+        if (contributions.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        } else {
+            return ResponseEntity.ok(contributions);
+        }
+    }
+
+    @PostMapping
+    public ResponseEntity<AssetContribution> addAssetContribution(@Valid @RequestBody AssetContribution assetContribution) {
+        assetContributionService.addAssetContribution(assetContribution);
+        return ResponseEntity.created(null).build();
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<AssetContribution> updateAssetContribution(
+            @PathVariable Long id,
+            @Valid @RequestBody AssetContribution assetContribution) {
+        if (assetContributionService.getAssetContributionById(id).isEmpty()) {
+            throw new AssetNotFoundException("Asset Contribution not found");
+        }
+        assetContribution.setId(id);
+        assetContributionService.updateAssetContribution(assetContribution);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteAssetContributionById(@PathVariable Long id) {
+        if (assetContributionService.getAssetContributionById(id).isEmpty()) {
+            throw new AssetNotFoundException("Asset Contribution not found");
+        }
+        assetContributionService.deleteAssetContributionById(id);
+        return ResponseEntity.ok().build();
+    }
+
+}
+

--- a/src/main/java/com/app/financial/investmentassetapp/controller/InvestmentsContributionController.java
+++ b/src/main/java/com/app/financial/investmentassetapp/controller/InvestmentsContributionController.java
@@ -1,0 +1,66 @@
+package com.app.financial.investmentassetapp.controller;
+
+import com.app.financial.investmentassetapp.excpetion.AssetNotFoundException;
+import com.app.financial.investmentassetapp.model.InvestmentsContribution;
+import com.app.financial.investmentassetapp.service.InvestmentsContributionService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/asset/investments-contribution")
+public class InvestmentsContributionController {
+
+    @Autowired
+    private InvestmentsContributionService investmentsContributionService;
+
+    @GetMapping
+    public ResponseEntity<List<InvestmentsContribution>> getAllInvestmentsContribution() {
+        List<InvestmentsContribution> contributions = investmentsContributionService.getAllInvestmentsContribution();
+        if (contributions.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        } else {
+            return ResponseEntity.ok(contributions);
+        }
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<InvestmentsContribution> getInvestmentsContributionById(@PathVariable Long id) {
+        Optional<InvestmentsContribution> contribution = investmentsContributionService.getInvestmentsContributionById(id);
+        return contribution.map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<InvestmentsContribution> addInvestmentsContribution(@Valid @RequestBody InvestmentsContribution investmentsContribution) {
+        investmentsContributionService.addInvestmentsContribution(investmentsContribution);
+        return ResponseEntity.created(null).build();
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<InvestmentsContribution> updateInvestmentsContribution(
+            @PathVariable Long id,
+            @Valid @RequestBody InvestmentsContribution investmentsContribution) {
+        if (investmentsContributionService.getInvestmentsContributionById(id).isEmpty()) {
+            throw new AssetNotFoundException("Investments Contribution not found");
+        }
+        investmentsContribution.setId(id);
+        investmentsContributionService.updateInvestmentsContribution(investmentsContribution);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteInvestmentsContributionById(@PathVariable Long id) {
+        if (investmentsContributionService.getInvestmentsContributionById(id).isEmpty()) {
+            throw new AssetNotFoundException("Investments Contribution not found");
+        }
+        investmentsContributionService.deleteInvestmentsContributionById(id);
+        return ResponseEntity.ok().build();
+    }
+
+}
+

--- a/src/main/java/com/app/financial/investmentassetapp/model/AssetContribution.java
+++ b/src/main/java/com/app/financial/investmentassetapp/model/AssetContribution.java
@@ -1,0 +1,38 @@
+package com.app.financial.investmentassetapp.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Setter
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name = "asset_contribution")
+public class AssetContribution {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_contribution")
+    private Long id;
+
+    @NotNull(message = "Asset not be null")
+    @ManyToOne
+    @JoinColumn(name = "id_asset")
+    private Asset asset;
+
+    @NotNull(message = "Contribution date not be null")
+    @Column(name = "contribution_date")
+    private LocalDate contributionDate;
+
+    @NotNull(message = "Value not be null")
+    @Column(name = "value", precision = 20, scale = 2)
+    private BigDecimal value;
+
+}
+

--- a/src/main/java/com/app/financial/investmentassetapp/model/InvestmentsContribution.java
+++ b/src/main/java/com/app/financial/investmentassetapp/model/InvestmentsContribution.java
@@ -1,0 +1,33 @@
+package com.app.financial.investmentassetapp.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Setter
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name = "investments_contribution")
+public class InvestmentsContribution {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_investments_contribution")
+    private Long id;
+
+    @NotNull(message = "Contribution date not be null")
+    @Column(name = "contribution_date")
+    private LocalDate contributionDate;
+
+    @NotNull(message = "Value not be null")
+    @Column(name = "value", precision = 20, scale = 2)
+    private BigDecimal value;
+
+}
+

--- a/src/main/java/com/app/financial/investmentassetapp/repository/AssetContributionRepositoryImpl.java
+++ b/src/main/java/com/app/financial/investmentassetapp/repository/AssetContributionRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.app.financial.investmentassetapp.repository;
+
+import com.app.financial.investmentassetapp.model.AssetContribution;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class AssetContributionRepositoryImpl {
+
+    @Autowired
+    private IAssetContributionRepository assetContributionRepository;
+
+    public List<AssetContribution> getAllAssetContribution() {
+        return assetContributionRepository.findAll();
+    }
+
+    public Optional<AssetContribution> getAssetContributionById(Long id) {
+        return assetContributionRepository.findById(id);
+    }
+
+    public List<AssetContribution> getContributionsByAssetId(Long assetId) {
+        return assetContributionRepository.findByAssetId(assetId);
+    }
+
+    public void addAssetContribution(AssetContribution assetContribution) {
+        assetContributionRepository.save(assetContribution);
+    }
+
+    public void updateAssetContribution(AssetContribution assetContribution) {
+        assetContributionRepository.save(assetContribution);
+    }
+
+    public void deleteAssetContributionById(Long id) {
+        assetContributionRepository.deleteById(id);
+    }
+
+}
+

--- a/src/main/java/com/app/financial/investmentassetapp/repository/IAssetContributionRepository.java
+++ b/src/main/java/com/app/financial/investmentassetapp/repository/IAssetContributionRepository.java
@@ -1,0 +1,12 @@
+package com.app.financial.investmentassetapp.repository;
+
+import com.app.financial.investmentassetapp.model.AssetContribution;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface IAssetContributionRepository extends JpaRepository<AssetContribution, Long> {
+    List<AssetContribution> findByAssetId(Long assetId);
+}
+

--- a/src/main/java/com/app/financial/investmentassetapp/repository/IInvestmentsContributionRepository.java
+++ b/src/main/java/com/app/financial/investmentassetapp/repository/IInvestmentsContributionRepository.java
@@ -1,0 +1,11 @@
+package com.app.financial.investmentassetapp.repository;
+
+import com.app.financial.investmentassetapp.model.InvestmentsContribution;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface IInvestmentsContributionRepository extends JpaRepository<InvestmentsContribution, Long> {
+}
+

--- a/src/main/java/com/app/financial/investmentassetapp/repository/InvestmentsContributionRepositoryImpl.java
+++ b/src/main/java/com/app/financial/investmentassetapp/repository/InvestmentsContributionRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.app.financial.investmentassetapp.repository;
+
+import com.app.financial.investmentassetapp.model.InvestmentsContribution;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class InvestmentsContributionRepositoryImpl {
+
+    @Autowired
+    private IInvestmentsContributionRepository investmentsContributionRepository;
+
+    public List<InvestmentsContribution> getAllInvestmentsContribution() {
+        return investmentsContributionRepository.findAll();
+    }
+
+    public Optional<InvestmentsContribution> getInvestmentsContributionById(Long id) {
+        return investmentsContributionRepository.findById(id);
+    }
+
+    public void addInvestmentsContribution(InvestmentsContribution investmentsContribution) {
+        investmentsContributionRepository.save(investmentsContribution);
+    }
+
+    public void updateInvestmentsContribution(InvestmentsContribution investmentsContribution) {
+        investmentsContributionRepository.save(investmentsContribution);
+    }
+
+    public void deleteInvestmentsContributionById(Long id) {
+        investmentsContributionRepository.deleteById(id);
+    }
+
+}
+

--- a/src/main/java/com/app/financial/investmentassetapp/service/AssetContributionService.java
+++ b/src/main/java/com/app/financial/investmentassetapp/service/AssetContributionService.java
@@ -1,0 +1,42 @@
+package com.app.financial.investmentassetapp.service;
+
+import com.app.financial.investmentassetapp.model.AssetContribution;
+import com.app.financial.investmentassetapp.repository.AssetContributionRepositoryImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class AssetContributionService {
+
+    @Autowired
+    private AssetContributionRepositoryImpl assetContributionRepository;
+
+    public List<AssetContribution> getAllAssetContribution() {
+        return assetContributionRepository.getAllAssetContribution();
+    }
+
+    public Optional<AssetContribution> getAssetContributionById(Long id) {
+        return assetContributionRepository.getAssetContributionById(id);
+    }
+
+    public List<AssetContribution> getContributionsByAssetId(Long assetId) {
+        return assetContributionRepository.getContributionsByAssetId(assetId);
+    }
+
+    public void addAssetContribution(AssetContribution assetContribution) {
+        assetContributionRepository.addAssetContribution(assetContribution);
+    }
+
+    public void updateAssetContribution(AssetContribution assetContribution) {
+        assetContributionRepository.updateAssetContribution(assetContribution);
+    }
+
+    public void deleteAssetContributionById(Long id) {
+        assetContributionRepository.deleteAssetContributionById(id);
+    }
+
+}
+

--- a/src/main/java/com/app/financial/investmentassetapp/service/InvestmentsContributionService.java
+++ b/src/main/java/com/app/financial/investmentassetapp/service/InvestmentsContributionService.java
@@ -1,0 +1,38 @@
+package com.app.financial.investmentassetapp.service;
+
+import com.app.financial.investmentassetapp.model.InvestmentsContribution;
+import com.app.financial.investmentassetapp.repository.InvestmentsContributionRepositoryImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class InvestmentsContributionService {
+
+    @Autowired
+    private InvestmentsContributionRepositoryImpl investmentsContributionRepository;
+
+    public List<InvestmentsContribution> getAllInvestmentsContribution() {
+        return investmentsContributionRepository.getAllInvestmentsContribution();
+    }
+
+    public Optional<InvestmentsContribution> getInvestmentsContributionById(Long id) {
+        return investmentsContributionRepository.getInvestmentsContributionById(id);
+    }
+
+    public void addInvestmentsContribution(InvestmentsContribution investmentsContribution) {
+        investmentsContributionRepository.addInvestmentsContribution(investmentsContribution);
+    }
+
+    public void updateInvestmentsContribution(InvestmentsContribution investmentsContribution) {
+        investmentsContributionRepository.updateInvestmentsContribution(investmentsContribution);
+    }
+
+    public void deleteInvestmentsContributionById(Long id) {
+        investmentsContributionRepository.deleteInvestmentsContributionById(id);
+    }
+
+}
+


### PR DESCRIPTION
## Summary

Adds full CRUD (Create, Read, Delete) for **AssetType** and **AssetSubType**, following the same layered pattern already used for **Bank** (Controller → Service → Repository Impl → JPA Repository).

## Changes

### AssetType

- **Repository:** `IAssetTypeRespository` (JpaRepository + `findByName`) and `AssetTypeRepositoryImpl`.
- **Service:** `AssetTypeService` with `getAllAssetType`, `getById`, `getByName`, `deleteAssetType`, `addAssetType`.
- **Controller:** `AssetTypeController` under `/asset/asset-type`.
  - `GET /asset/asset-type` — list all (204 if empty).
  - `GET /asset/asset-type/{id}` — get by id.
  - `GET /asset/asset-type/query?name=` — get by name.
  - `DELETE /asset/asset-type/{id}` — delete by id (throws `AssetNotFoundException` if not found).
  - `POST /asset/asset-type` — create (body: `{ "name": "..." }`).
- **Model:** `@JsonIgnore` on `AssetType.subTypes` to avoid circular serialization in the API.

### AssetSubType

- **Repository:** `IAssetSubTypeRespository` (JpaRepository + `findByName` + `findByAssetType_Id`) and `AssetSubTypeRepositoryImpl`.
- **Service:** `AssetSubTypeService` with list, get by id/name, get by asset type id, delete, add.
- **Controller:** `AssetSubTypeController` under `/asset/asset-sub-type`.
  - `GET /asset/asset-sub-type` — list all.
  - `GET /asset/asset-sub-type/{id}` — get by id.
  - `GET /asset/asset-sub-type/query?name=` — get by name.
  - `GET /asset/asset-sub-type/by-asset-type/{assetTypeId}` — list by AssetType id.
  - `DELETE /asset/asset-sub-type/{id}` — delete by id.
  - `POST /asset/asset-sub-type` — create (body: `{ "name": "...", "assetType": { "id": 1 } }`).

### Consistency

- Same structure as Bank: interface repository (typo `Respository` kept for consistency), `*RepositoryImpl`, service, REST controller with `AssetNotFoundException` on delete and `ResponseEntity.created(null)` on POST.

## Motivation

- Centralize management of asset types and sub-types via REST API.
- Keep the same architecture and naming used in the existing Bank CRUD for maintainability and onboarding.

## Checklist

- [x] AssetType CRUD (repository, service, controller) implemented.
- [x] AssetSubType CRUD (repository, service, controller) implemented.
- [x] Query by name and, for AssetSubType, by asset type id.
- [x] `@JsonIgnore` on `AssetType.subTypes` to avoid JSON circular reference.
- [x] No new dependencies; uses existing JPA, validation, and exception handling.
