### PR TITLE
feat: add updateQuotation endpoint and implement asset quotation update

### DIFF
--- a/src/main/java/com/app/financial/investmentassetapp/controller/AssetController.java
+++ b/src/main/java/com/app/financial/investmentassetapp/controller/AssetController.java
@@ -67,4 +67,10 @@ public class AssetController {
         return ResponseEntity.created(null).build();
     }
 
+    @PostMapping("/update-quotation")
+    public ResponseEntity<Asset> updateQuotationApp(){
+        assetServiceImpl.updateAssetQuotation();
+        return ResponseEntity.created(null).build();
+    }
+
 }

--- a/src/main/java/com/app/financial/investmentassetapp/external/QuotationExternal.java
+++ b/src/main/java/com/app/financial/investmentassetapp/external/QuotationExternal.java
@@ -17,7 +17,6 @@ public class QuotationExternal {
 
     RestTemplate restTemplate = new RestTemplate();
 
-
     public BigDecimal returnValueQuotationExternal(String nameAsset){
         System.out.println(returnQuotationAsList());
         return returnQuotationAsList().stream()
@@ -27,8 +26,6 @@ public class QuotationExternal {
                 .orElse(BigDecimal.ZERO);
     }
 
-
-
     public List<QuotationDTO> returnQuotationAsList() {
         URI uri = UriComponentsBuilder
                 .fromHttpUrl("http://localhost:8084/app/quotation")
@@ -37,10 +34,7 @@ public class QuotationExternal {
                 .toUri();
 
         QuotationDTO[] array = restTemplate.getForObject(uri, QuotationDTO[].class);
-        return Arrays.asList(array); // transforma em List<QuotationDTO>
+        return Arrays.asList(array);
     }
-
-
-
 
 }

--- a/src/main/java/com/app/financial/investmentassetapp/service/asset/AssetServiceImpl.java
+++ b/src/main/java/com/app/financial/investmentassetapp/service/asset/AssetServiceImpl.java
@@ -47,5 +47,18 @@ public class AssetServiceImpl{
         assetRepository.updateAsset(new AssetCalculatorImpl().calculatedValues(asset));
     }
 
+    public void updateAssetQuotation() {
+        List<Asset> listAssets = assetRepository.getAllAsset();
+
+        if (listAssets == null || listAssets.isEmpty()) {
+            return;
+        }
+
+        listAssets.forEach(asset -> {
+            BigDecimal quotation = new QuotationExternal().returnValueQuotationExternal(asset.getAsset());
+            asset.setQuotation(quotation);
+            assetRepository.updateAsset(new AssetCalculatorImpl().calculatedValues(asset));
+        });
+    }
 
 }


### PR DESCRIPTION
This pull request introduces a new feature for updating asset quotations in the application, along with some minor code cleanups. The main change is the addition of an endpoint and service logic to update all asset quotations based on external data.

### New Feature: Asset Quotation Update

* Added a new `POST /update-quotation` endpoint to `AssetController` that triggers the update of asset quotations for all assets.
* Implemented the `updateAssetQuotation` method in `AssetServiceImpl`, which retrieves all assets, fetches their latest quotations from an external service, updates each asset, and recalculates their values.

### Code Cleanups

* Removed unnecessary blank lines and comments in `QuotationExternal` to improve code readability. [[1]](diffhunk://#diff-d12d6700019075f44f4a459d81a7e1fe91632faff245aaaff5db2b99a03e3e98L20) [[2]](diffhunk://#diff-d12d6700019075f44f4a459d81a7e1fe91632faff245aaaff5db2b99a03e3e98L30-L31) [[3]](diffhunk://#diff-d12d6700019075f44f4a459d81a7e1fe91632faff245aaaff5db2b99a03e3e98L40-L45)
* Minor adjustment in `returnQuotationAsList` to remove redundant comment.